### PR TITLE
Fix conflicting error alert modifiers

### DIFF
--- a/Sources/DeenAssistUI/Navigation/AppCoordinator.swift
+++ b/Sources/DeenAssistUI/Navigation/AppCoordinator.swift
@@ -318,7 +318,6 @@ private struct MainAppView: View {
                 }
             )
         }
-        .errorAlert() // Add global error handling
         .errorAlert(
             error: $coordinator.currentError,
             onRetry: {


### PR DESCRIPTION
Remove redundant global `.errorAlert()` modifier to resolve conflicting error handling.