### PR TITLE
Fix metadata encoding for performance issue

### DIFF
--- a/DeenBuddy-iOS-Xcode-App/DeenBuddy/Frameworks/DeenAssistCore/Performance/PerformanceMonitor.swift
+++ b/DeenBuddy-iOS-Xcode-App/DeenBuddy/Frameworks/DeenAssistCore/Performance/PerformanceMonitor.swift
@@ -475,9 +475,40 @@ extension PerformanceIssue {
         try container.encode(severity, forKey: .severity)
         try container.encode(timestamp, forKey: .timestamp)
         
-        // Encode metadata as JSON data
-        let metadataData = try JSONSerialization.data(withJSONObject: metadata)
+        // Safely encode metadata by filtering out non-JSON-serializable values
+        let safeMetadata = filterJSONSerializableValues(from: metadata)
+        let metadataData = try JSONSerialization.data(withJSONObject: safeMetadata)
         try container.encode(metadataData, forKey: .metadata)
+    }
+    
+    /// Filters out non-JSON-serializable values from the metadata dictionary
+    private func filterJSONSerializableValues(from dict: [String: Any]) -> [String: Any] {
+        var safeDict: [String: Any] = [:]
+        
+        for (key, value) in dict {
+            if isJSONSerializable(value) {
+                safeDict[key] = value
+            } else {
+                // Replace non-serializable values with a string representation
+                safeDict[key] = "\(value)"
+            }
+        }
+        
+        return safeDict
+    }
+    
+    /// Checks if a value is JSON-serializable
+    private func isJSONSerializable(_ value: Any) -> Bool {
+        switch value {
+        case is String, is NSNumber, is Bool, is NSNull:
+            return true
+        case let array as [Any]:
+            return array.allSatisfy { isJSONSerializable($0) }
+        case let dict as [String: Any]:
+            return dict.values.allSatisfy { isJSONSerializable($0) }
+        default:
+            return false
+        }
     }
 }
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Safely encode `PerformanceIssue` metadata to prevent crashes when non-JSON-serializable types are present.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `metadata` property's type was changed to `[String: Any]`, which could include types not supported by `JSONSerialization.data(withJSONObject:)`. This PR adds helper methods to filter out or convert such values to strings, ensuring robust encoding.