### PR TITLE
Fix dependency injection in PrayerTimesView

### DIFF
--- a/DeenBuddy-iOS-Xcode-App/DeenBuddy/App/AppDependencyContainer.swift
+++ b/DeenBuddy-iOS-Xcode-App/DeenBuddy/App/AppDependencyContainer.swift
@@ -50,4 +50,9 @@ class AppDependencyContainer: ObservableObject {
             return nil
         }
     }
+    
+    // Access to the core container for views that need the full DependencyContainer
+    func getCoreContainer() -> DependencyContainer {
+        return coreContainer
+    }
 }

--- a/DeenBuddy-iOS-Xcode-App/DeenBuddy/Views/ContentView.swift
+++ b/DeenBuddy-iOS-Xcode-App/DeenBuddy/Views/ContentView.swift
@@ -13,7 +13,7 @@ struct ContentView: View {
     @EnvironmentObject var appContainer: AppDependencyContainer
     
     var body: some View {
-        PrayerTimesView(container: DependencyContainer.shared)
+        PrayerTimesView(container: appContainer.getCoreContainer())
     }
 }
 


### PR DESCRIPTION
Align `PrayerTimesView` dependency injection with `appContainer` to resolve type mismatch and runtime crash.