### PR TITLE
Fix JSON serialization for numeric types

### DIFF
--- a/DeenBuddy-iOS-Xcode-App/DeenBuddy/Frameworks/DeenAssistCore/Performance/PerformanceMonitor.swift
+++ b/DeenBuddy-iOS-Xcode-App/DeenBuddy/Frameworks/DeenAssistCore/Performance/PerformanceMonitor.swift
@@ -499,13 +499,33 @@ extension PerformanceIssue {
     
     /// Checks if a value is JSON-serializable
     private func isJSONSerializable(_ value: Any) -> Bool {
+        return isJSONSerializable(value, visited: Set<ObjectIdentifier>())
+    }
+    
+    /// Checks if a value is JSON-serializable with cycle detection
+    private func isJSONSerializable(_ value: Any, visited: Set<ObjectIdentifier>) -> Bool {
         switch value {
         case is String, is NSNumber, is Bool, is NSNull:
             return true
+        case is Int, is Int8, is Int16, is Int32, is Int64,
+             is UInt, is UInt8, is UInt16, is UInt32, is UInt64,
+             is Float, is Double:
+            return true
         case let array as [Any]:
-            return array.allSatisfy { isJSONSerializable($0) }
+            return array.allSatisfy { isJSONSerializable($0, visited: visited) }
         case let dict as [String: Any]:
-            return dict.values.allSatisfy { isJSONSerializable($0) }
+            return dict.values.allSatisfy { isJSONSerializable($0, visited: visited) }
+        case let object as AnyObject:
+            // Check for circular references
+            let objectId = ObjectIdentifier(object)
+            if visited.contains(objectId) {
+                return false // Circular reference detected
+            }
+            var newVisited = visited
+            newVisited.insert(objectId)
+            
+            // For objects, we'll be conservative and only allow if they can be converted to JSON
+            return false
         default:
             return false
         }

--- a/DeenBuddy-iOS-Xcode-App/DeenBuddy/Frameworks/DeenAssistCore/Performance/PerformanceMonitor.swift
+++ b/DeenBuddy-iOS-Xcode-App/DeenBuddy/Frameworks/DeenAssistCore/Performance/PerformanceMonitor.swift
@@ -521,13 +521,21 @@ extension PerformanceIssue {
             if visited.contains(objectId) { return false }
             visited.insert(objectId)
             defer { visited.remove(objectId) }
-            return (array as! [Any]).allSatisfy { isJSONSerializable($0, visited: &visited) }
+            if let swiftArray = array as? [Any] {
+                return swiftArray.allSatisfy { isJSONSerializable($0, visited: &visited) }
+            } else {
+                return false
+            }
         case let dict as NSDictionary:
             let objectId = ObjectIdentifier(dict)
             if visited.contains(objectId) { return false }
             visited.insert(objectId)
             defer { visited.remove(objectId) }
-            return (dict as! [AnyHashable: Any]).values.allSatisfy { isJSONSerializable($0, visited: &visited) }
+            if let swiftDict = dict as? [AnyHashable: Any] {
+                return swiftDict.values.allSatisfy { isJSONSerializable($0, visited: &visited) }
+            } else {
+                return false
+            }
         case let array as [Any]:
             // For Swift arrays (value types), cycles are not possible unless bridged
             // But if the array is bridged to NSArray, it will be caught above

--- a/Sources/DeenAssistCore/Performance/PerformanceMonitor.swift
+++ b/Sources/DeenAssistCore/Performance/PerformanceMonitor.swift
@@ -530,6 +530,10 @@ extension PerformanceIssue {
             if visited.contains(id) { return false }
             visited.insert(id)
             defer { visited.remove(id) }
+            // Ensure all keys are strings
+            for key in dict.allKeys {
+                if !(key is String) { return false }
+            }
             for value in dict.allValues {
                 if !isJSONSerializable(value, visited: &visited) { return false }
             }

--- a/Sources/DeenAssistCore/Performance/PerformanceMonitor.swift
+++ b/Sources/DeenAssistCore/Performance/PerformanceMonitor.swift
@@ -513,42 +513,52 @@ extension PerformanceIssue {
              is UInt, is UInt8, is UInt16, is UInt32, is UInt64,
              is Float, is Double:
             return true
+        case is NSData, is NSDate:
+            // NSData and NSDate are not directly JSON-serializable
+            return false
         case let array as NSArray:
             let objectId = ObjectIdentifier(array)
             if visited.contains(objectId) { return false }
             visited.insert(objectId)
             defer { visited.remove(objectId) }
-            // NSArray may contain non-JSON-serializable elements
             return (array as! [Any]).allSatisfy { isJSONSerializable($0, visited: &visited) }
         case let dict as NSDictionary:
             let objectId = ObjectIdentifier(dict)
             if visited.contains(objectId) { return false }
             visited.insert(objectId)
             defer { visited.remove(objectId) }
-            // NSDictionary may contain non-JSON-serializable values
             return (dict as! [AnyHashable: Any]).values.allSatisfy { isJSONSerializable($0, visited: &visited) }
         case let array as [Any]:
-            let objectId = ObjectIdentifier(array as AnyObject)
+            // Box Swift array in a reference wrapper for stable identity
+            class ArrayBox { let array: [Any]; init(_ a: [Any]) { array = a } }
+            let box = ArrayBox(array)
+            let objectId = ObjectIdentifier(box)
             if visited.contains(objectId) { return false }
             visited.insert(objectId)
             defer { visited.remove(objectId) }
             return array.allSatisfy { isJSONSerializable($0, visited: &visited) }
         case let dict as [String: Any]:
-            let objectId = ObjectIdentifier(dict as AnyObject)
+            // Box Swift dictionary in a reference wrapper for stable identity
+            class DictBox { let dict: [String: Any]; init(_ d: [String: Any]) { dict = d } }
+            let box = DictBox(dict)
+            let objectId = ObjectIdentifier(box)
             if visited.contains(objectId) { return false }
             visited.insert(objectId)
             defer { visited.remove(objectId) }
             return dict.values.allSatisfy { isJSONSerializable($0, visited: &visited) }
         case let object as AnyObject:
             // Only composite Foundation types should be tracked; basic types are handled above
-            if object is NSString || object is NSNumber || object is NSNull || object is NSData || object is NSDate {
+            if object is NSString || object is NSNumber || object is NSNull {
                 return true
+            }
+            // NSData and NSDate are not JSON-serializable
+            if object is NSData || object is NSDate {
+                return false
             }
             let objectId = ObjectIdentifier(object)
             if visited.contains(objectId) { return false }
             visited.insert(objectId)
             defer { visited.remove(objectId) }
-            // Try to treat as dictionary or array
             if let dict = object as? [String: Any] {
                 return dict.values.allSatisfy { isJSONSerializable($0, visited: &visited) }
             } else if let array = object as? [Any] {

--- a/Sources/DeenAssistCore/Performance/PerformanceMonitor.swift
+++ b/Sources/DeenAssistCore/Performance/PerformanceMonitor.swift
@@ -506,29 +506,55 @@ extension PerformanceIssue {
     
     /// Checks if a value is JSON-serializable with cycle detection
     private func isJSONSerializable(_ value: Any, visited: inout Set<ObjectIdentifier>) -> Bool {
+        // Handle all basic types (including Foundation bridged types)
         switch value {
-        case is String, is NSNumber, is Bool, is NSNull:
-            return true
-        case is Int, is Int8, is Int16, is Int32, is Int64,
+        case is String, is NSNumber, is Bool, is NSNull,
+             is Int, is Int8, is Int16, is Int32, is Int64,
              is UInt, is UInt8, is UInt16, is UInt32, is UInt64,
              is Float, is Double:
             return true
+        case let array as NSArray:
+            let objectId = ObjectIdentifier(array)
+            if visited.contains(objectId) { return false }
+            visited.insert(objectId)
+            defer { visited.remove(objectId) }
+            // NSArray may contain non-JSON-serializable elements
+            return (array as! [Any]).allSatisfy { isJSONSerializable($0, visited: &visited) }
+        case let dict as NSDictionary:
+            let objectId = ObjectIdentifier(dict)
+            if visited.contains(objectId) { return false }
+            visited.insert(objectId)
+            defer { visited.remove(objectId) }
+            // NSDictionary may contain non-JSON-serializable values
+            return (dict as! [AnyHashable: Any]).values.allSatisfy { isJSONSerializable($0, visited: &visited) }
         case let array as [Any]:
+            let objectId = ObjectIdentifier(array as AnyObject)
+            if visited.contains(objectId) { return false }
+            visited.insert(objectId)
+            defer { visited.remove(objectId) }
             return array.allSatisfy { isJSONSerializable($0, visited: &visited) }
         case let dict as [String: Any]:
+            let objectId = ObjectIdentifier(dict as AnyObject)
+            if visited.contains(objectId) { return false }
+            visited.insert(objectId)
+            defer { visited.remove(objectId) }
             return dict.values.allSatisfy { isJSONSerializable($0, visited: &visited) }
         case let object as AnyObject:
-            let objectId = ObjectIdentifier(object)
-            if visited.contains(objectId) {
-                return false // Circular reference detected
+            // Only composite Foundation types should be tracked; basic types are handled above
+            if object is NSString || object is NSNumber || object is NSNull || object is NSData || object is NSDate {
+                return true
             }
+            let objectId = ObjectIdentifier(object)
+            if visited.contains(objectId) { return false }
             visited.insert(objectId)
+            defer { visited.remove(objectId) }
+            // Try to treat as dictionary or array
             if let dict = object as? [String: Any] {
                 return dict.values.allSatisfy { isJSONSerializable($0, visited: &visited) }
             } else if let array = object as? [Any] {
                 return array.allSatisfy { isJSONSerializable($0, visited: &visited) }
             } else {
-                return object is String || object is NSNumber || object is Bool || object is NSNull
+                return false // Non-serializable custom object
             }
         default:
             return false


### PR DESCRIPTION
Enhance `isJSONSerializable` to support Swift native numbers and prevent circular reference stack overflows.

Previously, `isJSONSerializable` only recognized `NSNumber`, causing Swift native numeric types (e.g., `Int`, `Double`) to be incorrectly treated as non-serializable and converted to strings. Additionally, its recursive nature lacked cycle detection, leading to stack overflows with circular metadata references, a regression from prior handling.