### PR TITLE
Fix precision loss in convertToDouble function

### DIFF
--- a/DeenBuddy-iOS-Xcode-App/DeenBuddy/Frameworks/DeenAssistCore/Performance/PerformanceMonitor.swift
+++ b/DeenBuddy-iOS-Xcode-App/DeenBuddy/Frameworks/DeenAssistCore/Performance/PerformanceMonitor.swift
@@ -419,6 +419,7 @@ private enum JSONValue: Codable {
     case object([String: Any])
     
     // Helper function to convert any numeric type to Double
+    // For large integers (Int64, UInt64), we preserve them as strings to avoid precision loss
     private static func convertToDouble(_ value: Any) -> Double? {
         if let double = value as? Double {
             return double
@@ -435,7 +436,14 @@ private enum JSONValue: Codable {
         } else if let int32 = value as? Int32 {
             return Double(int32)
         } else if let int64 = value as? Int64 {
-            return Double(int64)
+            // Check if the value can be safely converted to Double without precision loss
+            // Double can safely represent integers up to 2^53
+            let maxSafeInteger: Int64 = 1 << 53
+            if int64 >= -maxSafeInteger && int64 <= maxSafeInteger {
+                return Double(int64)
+            }
+            // For large values, return nil to indicate they should be handled as strings
+            return nil
         } else if let uint = value as? UInt {
             return Double(uint)
         } else if let uint8 = value as? UInt8 {
@@ -445,7 +453,14 @@ private enum JSONValue: Codable {
         } else if let uint32 = value as? UInt32 {
             return Double(uint32)
         } else if let uint64 = value as? UInt64 {
-            return Double(uint64)
+            // Check if the value can be safely converted to Double without precision loss
+            // Double can safely represent integers up to 2^53
+            let maxSafeInteger: UInt64 = 1 << 53
+            if uint64 <= maxSafeInteger {
+                return Double(uint64)
+            }
+            // For large values, return nil to indicate they should be handled as strings
+            return nil
         }
         return nil
     }
@@ -534,6 +549,12 @@ private enum JSONValue: Codable {
             return .string(string)
         } else if let double = convertToDouble(value) {
             return .number(double)
+        } else if let int64 = value as? Int64 {
+            // Large Int64 values that couldn't be converted to Double are preserved as strings
+            return .string(String(int64))
+        } else if let uint64 = value as? UInt64 {
+            // Large UInt64 values that couldn't be converted to Double are preserved as strings
+            return .string(String(uint64))
         } else if let bool = value as? Bool {
             return .bool(bool)
         } else if value is NSNull {

--- a/DeenBuddy-iOS-Xcode-App/DeenBuddy/Frameworks/DeenAssistCore/Performance/PerformanceMonitor.swift
+++ b/DeenBuddy-iOS-Xcode-App/DeenBuddy/Frameworks/DeenAssistCore/Performance/PerformanceMonitor.swift
@@ -424,7 +424,14 @@ private enum JSONValue: Codable {
         if let double = value as? Double {
             return double
         } else if let int = value as? Int {
-            return Double(int)
+            // Check if the value can be safely converted to Double without precision loss
+            // Double can safely represent integers up to 2^53
+            let maxSafeInteger: Int = 9007199254740992 // 2^53
+            if int >= -maxSafeInteger && int <= maxSafeInteger {
+                return Double(int)
+            }
+            // For large values, return nil to indicate they should be handled as strings
+            return nil
         } else if let float = value as? Float {
             return Double(float)
         } else if let cgFloat = value as? CGFloat {
@@ -438,14 +445,21 @@ private enum JSONValue: Codable {
         } else if let int64 = value as? Int64 {
             // Check if the value can be safely converted to Double without precision loss
             // Double can safely represent integers up to 2^53
-            let maxSafeInteger: Int64 = 1 << 53
+            let maxSafeInteger: Int64 = 9007199254740992 // 2^53
             if int64 >= -maxSafeInteger && int64 <= maxSafeInteger {
                 return Double(int64)
             }
             // For large values, return nil to indicate they should be handled as strings
             return nil
         } else if let uint = value as? UInt {
-            return Double(uint)
+            // Check if the value can be safely converted to Double without precision loss
+            // Double can safely represent integers up to 2^53
+            let maxSafeInteger: UInt = 9007199254740992 // 2^53
+            if uint <= maxSafeInteger {
+                return Double(uint)
+            }
+            // For large values, return nil to indicate they should be handled as strings
+            return nil
         } else if let uint8 = value as? UInt8 {
             return Double(uint8)
         } else if let uint16 = value as? UInt16 {
@@ -455,7 +469,7 @@ private enum JSONValue: Codable {
         } else if let uint64 = value as? UInt64 {
             // Check if the value can be safely converted to Double without precision loss
             // Double can safely represent integers up to 2^53
-            let maxSafeInteger: UInt64 = 1 << 53
+            let maxSafeInteger: UInt64 = 9007199254740992 // 2^53
             if uint64 <= maxSafeInteger {
                 return Double(uint64)
             }
@@ -549,6 +563,12 @@ private enum JSONValue: Codable {
             return .string(string)
         } else if let double = convertToDouble(value) {
             return .number(double)
+        } else if let int = value as? Int {
+            // Large Int values that couldn't be converted to Double are preserved as strings
+            return .string(String(int))
+        } else if let uint = value as? UInt {
+            // Large UInt values that couldn't be converted to Double are preserved as strings
+            return .string(String(uint))
         } else if let int64 = value as? Int64 {
             // Large Int64 values that couldn't be converted to Double are preserved as strings
             return .string(String(int64))

--- a/DeenBuddy-iOS-Xcode-App/DeenBuddy/Frameworks/DeenAssistUI/Mocks/MockSettingsService.swift
+++ b/DeenBuddy-iOS-Xcode-App/DeenBuddy/Frameworks/DeenAssistUI/Mocks/MockSettingsService.swift
@@ -11,7 +11,8 @@ public class MockSettingsService: SettingsServiceProtocol {
     @Published public var timeFormat: TimeFormat = .twelveHour
     @Published public var notificationOffset: TimeInterval = 300
     @Published public var hasCompletedOnboarding: Bool = false
-    
+    @Published public var overrideBatteryOptimization: Bool = false
+
     public var enableNotifications: Bool {
         get { notificationsEnabled }
         set { notificationsEnabled = newValue }
@@ -31,6 +32,7 @@ public class MockSettingsService: SettingsServiceProtocol {
         print("- Time Format: \(timeFormat.displayName)")
         print("- Notification Offset: \(notificationOffset)")
         print("- Onboarding Complete: \(hasCompletedOnboarding)")
+        print("- Override Battery Optimization: \(overrideBatteryOptimization)")
     }
     
     public func loadSettings() async throws {
@@ -45,6 +47,7 @@ public class MockSettingsService: SettingsServiceProtocol {
         timeFormat = .twelveHour
         notificationOffset = 300
         hasCompletedOnboarding = false
+        overrideBatteryOptimization = false
         
         print("Mock: Settings loaded")
     }
@@ -60,6 +63,7 @@ public class MockSettingsService: SettingsServiceProtocol {
         timeFormat = .twelveHour
         notificationOffset = 300
         hasCompletedOnboarding = false
+        overrideBatteryOptimization = false
         
         print("Mock: Settings reset to defaults")
     }

--- a/Sources/DeenAssistCore/Performance/PerformanceMonitor.swift
+++ b/Sources/DeenAssistCore/Performance/PerformanceMonitor.swift
@@ -425,7 +425,14 @@ private enum JSONValue: Codable {
         if let double = value as? Double {
             return double
         } else if let int = value as? Int {
-            return Double(int)
+            // Check if the value can be safely converted to Double without precision loss
+            // Double can safely represent integers up to 2^53
+            let maxSafeInteger: Int = 9007199254740992 // 2^53
+            if int >= -maxSafeInteger && int <= maxSafeInteger {
+                return Double(int)
+            }
+            // For large values, return nil to indicate they should be handled as strings
+            return nil
         } else if let float = value as? Float {
             return Double(float)
         } else if let cgFloat = value as? CGFloat {
@@ -439,14 +446,21 @@ private enum JSONValue: Codable {
         } else if let int64 = value as? Int64 {
             // Check if the value can be safely converted to Double without precision loss
             // Double can safely represent integers up to 2^53
-            let maxSafeInteger: Int64 = 1 << 53
+            let maxSafeInteger: Int64 = 9007199254740992 // 2^53
             if int64 >= -maxSafeInteger && int64 <= maxSafeInteger {
                 return Double(int64)
             }
             // For large values, return nil to indicate they should be handled as strings
             return nil
         } else if let uint = value as? UInt {
-            return Double(uint)
+            // Check if the value can be safely converted to Double without precision loss
+            // Double can safely represent integers up to 2^53
+            let maxSafeInteger: UInt = 9007199254740992 // 2^53
+            if uint <= maxSafeInteger {
+                return Double(uint)
+            }
+            // For large values, return nil to indicate they should be handled as strings
+            return nil
         } else if let uint8 = value as? UInt8 {
             return Double(uint8)
         } else if let uint16 = value as? UInt16 {
@@ -456,7 +470,7 @@ private enum JSONValue: Codable {
         } else if let uint64 = value as? UInt64 {
             // Check if the value can be safely converted to Double without precision loss
             // Double can safely represent integers up to 2^53
-            let maxSafeInteger: UInt64 = 1 << 53
+            let maxSafeInteger: UInt64 = 9007199254740992 // 2^53
             if uint64 <= maxSafeInteger {
                 return Double(uint64)
             }
@@ -550,6 +564,12 @@ private enum JSONValue: Codable {
             return .string(string)
         } else if let double = convertToDouble(value) {
             return .number(double)
+        } else if let int = value as? Int {
+            // Large Int values that couldn't be converted to Double are preserved as strings
+            return .string(String(int))
+        } else if let uint = value as? UInt {
+            // Large UInt values that couldn't be converted to Double are preserved as strings
+            return .string(String(uint))
         } else if let int64 = value as? Int64 {
             // Large Int64 values that couldn't be converted to Double are preserved as strings
             return .string(String(int64))


### PR DESCRIPTION
Preserve precision for large `Int64` and `UInt64` values by serializing them as strings instead of `Double`.

The `convertToDouble` helper function was converting `Int64` and `UInt64` directly to `Double`, leading to silent data corruption for values larger than 2^53 due to `Double`'s limited integer precision. This change modifies `convertToDouble` to return `nil` for such large values, and updates `fromAny` to then serialize these values as strings, ensuring exact precision is maintained.